### PR TITLE
Specify -B -ntp options when running mvn deploy

### DIFF
--- a/.github/workflows/deploy-artifacts.yml
+++ b/.github/workflows/deploy-artifacts.yml
@@ -29,7 +29,7 @@ jobs:
           gpg-private-key: ${{secrets.gpgPrivateKey}}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Deploy to Maven Central
-        run: mvn deploy -DskipTests
+        run: mvn -B -ntp deploy -DskipTests
         env:
           MAVEN_USERNAME: ${{secrets.centralUsername}}
           MAVEN_CENTRAL_TOKEN: ${{secrets.centralPassword}}


### PR DESCRIPTION
# Overview

Specify `-B -ntp` options when running `mvn deploy` to reduce noisy log outputs.
